### PR TITLE
Added support for bulma "icon" component + fa/fa- support

### DIFF
--- a/src/plugin/components.js
+++ b/src/plugin/components.js
@@ -10,7 +10,9 @@ const outerElementsMap = new Map([
   ['label', 'label'],
   ['button', 'button'],
   ['image', 'figure'],
-  ['form', 'form']
+  ['form', 'form'],
+  ['icon', 'span'],
+  ['fa', 'i']
 ])
 
 export const componentGenerator = (name, reqOuterElement) => ({
@@ -99,5 +101,6 @@ export default [
   'container',
   'hero',
   'hero-body',
-  'input'
+  'input',
+  'fa'
 ]

--- a/src/plugin/components.js
+++ b/src/plugin/components.js
@@ -26,7 +26,8 @@ export const componentGenerator = (name, reqOuterElement) => ({
           .map(str => camelCaseToDash(str))
           .filter(key => (
             ((key.substring(0, 3) === 'is-') ||
-            (key.substring(0, 4) === 'has-'))
+            (key.substring(0, 4) === 'has-') ||
+            (key.substring(0,3) === 'fa-'))
           ))
         ],
         ...data


### PR DESCRIPTION
Consider the following bulma snippet:

    <span class="icon">
        <i class="fa fa-home"></i>
    </span>

Before this PR, it needs to be done like this:

    <icon outerElement="span">
        <i class="fa fa-home"></i>
    </icon>

After this PR:

    <icon>
        <fa fa-home></fa>
    </icon>

I hope you agree this is better! :)