### PR TITLE
Register component name to PascalCase

### DIFF
--- a/src/plugin/helpers.js
+++ b/src/plugin/helpers.js
@@ -163,6 +163,17 @@ export const camelCaseToDash = myStr =>
     .toLowerCase()
     .replace(/(([a-z])(?![0-9]))([a-z])([0-9])/g, '$2$3-$4')
 
+export const toPascalCase = str => {
+  if (!str) return ''
+
+  return String(str)
+    .replace(/^[^A-Za-z0-9]*|[^A-Za-z0-9]*$/g, '$')
+    .replace(/[^A-Za-z0-9]+/g, '$')
+    .replace(/([a-z])([A-Z])/g, (m, a, b) => a + '$' + b)
+    .toLowerCase()
+    .replace(/(\$)(\w?)/g, (m, a, b) => b.toUpperCase())
+}
+
 // thanks the solution @israelroldan
 export const isBulmaAttribute = attr =>
   attr.trim() && /^(is|has|fa)-.+/.test(attr)

--- a/src/plugin/plugin.js
+++ b/src/plugin/plugin.js
@@ -1,11 +1,12 @@
 import { componentGenerator } from './components'
-import { bulmaComponentList } from './helpers'
+import { bulmaComponentList, toPascalCase } from './helpers'
 
 let plugin = {}
 
 plugin.install = function (Vue, option) {
   bulmaComponentList.forEach(name => {
-    Vue.component(`${(option && option.prefix) || 'b-'}${name}`, componentGenerator(name, (option && option.outerElement[name]) || ''))
+    const componentName = toPascalCase(`${(option && option.prefix) || 'b-'}${name}`)
+    Vue.component(componentName, componentGenerator(name, (option && option.outerElement[name]) || ''))
   })
 }
 


### PR DESCRIPTION
`<BButton>` will be an unknown custom element, because this plugin was registered the component with name like `kebab-case`.

Register the component with name like `PascalCase`, works fine with `<b-button>` and `<BButton>`.